### PR TITLE
New fields in the raw_slack_jobs table; src_slack_jobs model is updated accordingly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ Here's what I am currently building, as a DAG.
 
 ![Image](img/dag.png)
 
-Here's some additional details for the tables undergoing transformations. 
+Examples of transformations performed:
+- [ ] Slack data consists of threaded messages. The data we want (the job announcement) is the parent message in any given thread. 
+- [ ] Tweet data includes duplicate tweets. We need to remove those duplicates.
+- [x] Data from multiple sources needs to be merged and presented in a single list.
+- [x] We want to identify from unstructured text which jobs are potentially remote, contract, and/or part-time.
+- [ ] We want to present unstructured, messy text in a more human-readable format.
 
-![Image](img/transformations.png)
 
 

--- a/dbt/models/src/src_slack_jobs.sql
+++ b/dbt/models/src/src_slack_jobs.sql
@@ -2,12 +2,11 @@ WITH raw_slack_jobs AS (
   SELECT * FROM {{ source('bigquery', 'raw_slack_jobs')}}
 )
 SELECT
-   {{ dbt_utils.generate_surrogate_key(
-      ['text']
-  ) }} as slack_id, -- generate primary key
+   {{ dbt_utils.generate_surrogate_key(['text']) }} as slack_id, -- generate primary key
   text as slack_text,
   url as slack_url,
   timestamp,
-  thread_id,
+  thread_ts, -- if ts = thread_ts, the row represents a 'parent message'
+  ts, -- id of the message, guaranteed unique within the channel or conversation
   workspace
 FROM raw_slack_jobs


### PR DESCRIPTION
Specifically, thread_ts and ts fields are added to the raw_slack_jobs table so we can distinguish parent messages (i.e. job posts) from replies. 

User related fields have been removed since we weren't using them. 